### PR TITLE
Adding function to download Collections as ZIP

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,5 +1,6 @@
 class CollectionsController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:index, :show]
+  require "zip"
+  skip_before_action :authenticate_user!, only: [:index, :show, :bulk_download]
 
   def index
     @collections = policy_scope(Collection)
@@ -65,6 +66,36 @@ class CollectionsController < ApplicationController
     @collection.destroy
     flash[:notice] = "Collection successfully deleted."
     redirect_to collections_users_path
+  end
+
+  def bulk_download
+    @collection = Collection.friendly.find(params[:id])
+    authorize @collection
+    filename = "#{@collection.name}.zip"
+    temp_file = Tempfile.new(filename)
+
+    begin
+      # Zip::OutputStream.open(temp_file) { |zos| }
+
+      Zip::File.open(temp_file.path, Zip::File::CREATE) do |zipfile|
+        titles = []
+        mod_id = @mods.first.id
+        @collection.blueprints.select([:mod_id, :collection_id, :title, :encoded_blueprint]).where(mod_id: mod_id).each do |blueprint|
+          title = blueprint.title
+          title += "_#{titles.count(title)}" if titles.count(title).positive?
+          titles += [blueprint.title]
+          blueprint_file = Tempfile.new("#{title}.txt")
+          blueprint_file.write(blueprint.encoded_blueprint)
+          zipfile.add("#{@collection.name}/#{title}.txt", blueprint_file.path)
+        end
+      end
+
+      zip_data = File.read(temp_file.path)
+      send_data(zip_data, type: "application/zip", disposition: "attachment", filename: filename)
+    ensure # important steps below
+      temp_file.close
+      temp_file.unlink
+    end
   end
 
   private

--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -24,4 +24,8 @@ class CollectionPolicy < ApplicationPolicy
   def destroy?
     record.user == user
   end
+
+  def bulk_download?
+    true
+  end
 end

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -4,6 +4,7 @@
       <span class="p-page__header-title-main" target="_blank" rel="noopener noreferrer"><%= @collection.name %> <span class="author">collection by <%= @collection.user.username %></span> </span>
     </h1>
     <br />
+    <%= link_to 'Download all as ZIP', bulk_download_collection_path(@collection), class: 'a-button', download: "#{@collection.name}.zip" %>
   </div>
   <% if @blueprints.any? %>
     <%= render "blueprints/shared/list", blueprints: @blueprints %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,5 +31,9 @@ Rails.application.routes.draw do
       put "unlike", to: "blueprints#unlike"
     end
   end
-  resources :collections, only: [:new, :show, :index, :edit, :create, :update, :destroy]
+  resources :collections, only: [:new, :show, :index, :edit, :create, :update, :destroy] do
+    member do
+      get "bulk_download", to: "collections#bulk_download"
+    end
+  end
 end


### PR DESCRIPTION
This adds a function to download a Collection as a ZIP file.
It zips all blueprints in the collection and lets the user download that.
See #22 for the feature request