### PR TITLE
Added ability to display blueprint item composition in upload form

### DIFF
--- a/app/assets/stylesheets/pages/_blueprint.scss
+++ b/app/assets/stylesheets/pages/_blueprint.scss
@@ -124,11 +124,56 @@
         }
       }
 
+      &__recipe--fixed-margin {
+        display: inline-flex;
+        align-items: center;
+        cursor: default;
+        margin: 0 0 4px 10px;
+      }
+
       &:last-child {
         border-bottom: none;
         margin-bottom: 0;
         padding-bottom: 0;
       }
+
+      &__params {
+        display: flex;
+        list-style: none;
+        justify-content: flex-end;
+        flex-wrap: wrap;
+        margin: 0 0 8px 0;
+        padding: 0;
+        position: relative;
+        border-bottom: dashed var(--blue);
+
+        img {
+          width: 32px;
+          margin-left: 8px;
+        }
+      }
+
+      &__param {
+        display: inline-flex;
+        align-items: center;
+        cursor: default;
+        margin: 0 0 4px 10px;
+
+        img {
+          width: 40px;
+          margin-left: 8px;
+        }
+
+        li {
+          list-style: none;
+        }
+      }
+    }
+
+    &-preview {
+      background: var(--dark-blue);
+      padding: 12px 12px 6px 12px;
+      margin-bottom: 12px;
     }
 
     &-error {

--- a/app/javascript/controllers/bp_parser_controller.js
+++ b/app/javascript/controllers/bp_parser_controller.js
@@ -1,0 +1,166 @@
+import { Controller } from 'stimulus'
+import DspBpParser from 'dsp-bp-parser';
+import items from '../data/gameEntities.json';
+import recipes from '../data/gameRecipes.json';
+
+const images = require.context('../../assets/images/game_icons', true)
+const imagePath = name => images(name, true)
+
+
+export default class extends Controller {
+  static targets = ['value']
+
+  connect() {
+    if (this.valueTarget.value.length !== 0) {
+      this.parse();
+    }
+  }
+
+  parse() {
+    const data = new DspBpParser(this.valueTarget.value)
+    this.render(data);
+  }
+
+  render(data) {
+    if (document.querySelector('.t-blueprint__requirements-preview')) {
+      document.querySelector('.t-blueprint__requirements-preview').remove();
+    }
+
+    if ('content' in document.createElement('template')) {
+      const bpElement = document.querySelector('.m-form__important');
+      const bpRequirementsTemplate = document.querySelector('#bp-requirements');
+      const bpEntityTemplate = document.querySelector('#bp-entity');
+      const bpEntityRecipesTemplate = document.querySelector('#bp-entity-recipes');
+      const bpEntityRecipeTemplate = document.querySelector('#bp-entity-recipe');
+      const bpEntityParamsTemplate = document.querySelector('#bp-entity-params');
+      const bpEntityParamTemplate = document.querySelector('#bp-entity-param');
+
+      // Total structure
+      let bpReq = bpRequirementsTemplate.content.cloneNode(true);
+      bpReq.querySelector("#totalStructure").textContent = data.summary.totalStructure;
+      bpElement.append(bpReq);
+
+      // Item list
+      const bpEntityList = document.querySelector('#bp-entity-list');
+
+      // Building
+      for (const [itemId, _] of Object.entries(data.summary.buildings)) {
+        let bpEnt = bpEntityTemplate.content.cloneNode(true);
+        let bpEntRecipes = bpEntityRecipesTemplate.content.cloneNode(true);
+        let image = this.createImageElement(imagePath(`./entities/${itemId}.png`));
+
+        // [Building] Assign image
+        const entityImageEl = bpEnt.querySelector("#entity-image");
+        entityImageEl.appendChild(image);
+
+        // [Building] Assign tooltip
+        this.createTooltip(entityImageEl, items[itemId]);
+
+        // [Building] Assign count
+        bpEnt.querySelector("#entity-tally").textContent = data.summary.buildings[itemId].count;
+
+        // BuildingRecipe
+        for (const [recipeId, count] of Object.entries(data.summary.buildings[itemId].recipeIds)) {
+          let bpEntRecipe = bpEntityRecipeTemplate.content.cloneNode(true);
+          let image = this.createImageElement(imagePath(`./recipes/${recipeId}.png`));
+
+          // [BuildingRecipe] Assign image
+          const entityRecipeImageEl = bpEntRecipe.querySelector('#entity-recipe-image')
+          entityRecipeImageEl.appendChild(image);
+
+          // [BuildingRecipe] Assign tooltip
+          this.createTooltip(entityRecipeImageEl, recipes[recipeId]);
+
+          // [BuildingRecipe] Assign count
+          bpEntRecipe.querySelector('#entity-recipe-tally').textContent = count;
+
+          bpEntRecipes.querySelector('.t-blueprint__requirements-entity__recipes').appendChild(bpEntRecipe);
+        }
+        bpEnt.appendChild(bpEntRecipes);
+
+        // StationItem
+        data.summary.buildings[itemId].parameters.forEach(param => {
+          if (param.hasOwnProperty('itemCount')) {
+            let bpEntParams = bpEntityParamsTemplate.content.cloneNode(true);
+
+            param.itemSettings.forEach(p => {
+              if (p.itemId === 0) { return; }
+
+              let bpEntParam = bpEntityParamTemplate.content.cloneNode(true);
+              let image = this.createImageElement(imagePath(`./entities/${p.itemId}.png`));
+
+              // [StationItem] Assign image
+              const entityRecipeImageEl =
+              bpEntParam.querySelector("#entity-recipe-image").appendChild(image);
+
+              // [StationItem] Assign tooltip
+              this.createTooltip(entityRecipeImageEl, items[p.itemId]);
+
+              // [StationItem] Assign label
+              bpEntParam.querySelector('#entity-param-local').textContent = `Local: ${this.convertLogicLabel(p.localLogic)}`;
+              bpEntParam.querySelector('#entity-param-remote').textContent = `Remote: ${this.convertLogicLabel(p.remoteLogic)}`;
+              bpEntParam.querySelector('#entity-param-max').textContent = `Max: ${p.max}`;
+
+              bpEntParams.querySelector('.t-blueprint__requirements-entity__params').appendChild(bpEntParam);
+            })
+
+            bpEnt.appendChild(bpEntParams);
+          }
+        })
+        bpEntityList.appendChild(bpEnt);
+      }
+
+      // Inserter
+      this.createItem(bpEntityTemplate, bpEntityList, data.summary.inserters)
+
+      // Belt
+      this.createItem(bpEntityTemplate, bpEntityList, data.summary.belts)
+    }
+  }
+
+  convertLogicLabel(value) {
+    switch (value) {
+      case 0:
+        return 'Supply';
+      case 1:
+        return 'Demand';
+      case 2:
+        return 'Storage';
+    }
+  }
+
+  createImageElement(path) {
+    let imgElement = document.createElement('img');
+    imgElement.src = path;
+
+    return imgElement;
+  }
+
+  createItem(entTpl, entList, data) {
+    for (const [itemId, count] of Object.entries(data)) {
+      if (count === 0) { continue; }
+
+      let bpEnt = entTpl.content.cloneNode(true);
+      let image = this.createImageElement(imagePath(`./entities/${itemId}.png`));
+
+      // Assign image
+      const entityImageEl = bpEnt.querySelector("#entity-image");
+      entityImageEl.appendChild(image);
+
+      // Assign tooltip
+      this.createTooltip(entityImageEl, items[itemId]);
+
+      // Assign count
+      bpEnt.querySelector("#entity-tally").textContent = count;
+
+      entList.appendChild(bpEnt);
+    }
+  }
+
+  createTooltip(el, name) {
+    el.classList.add('tooltip-trigger');
+    el.dataset.controller = 'tooltip';
+    el.dataset.tippyContent = name;
+    el.dataset.tippyPlacement = 'bottom';
+  }
+}

--- a/app/views/blueprints/shared/_form.html.erb
+++ b/app/views/blueprints/shared/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="m-form">
   <% blueprint.errors.full_messages %>
-  <div class="m-form__container">
+  <div class="m-form__container" data-controller="bp-parser">
     <h1 class="m-form__title"><%= form_title %></h1>
 
     <%= simple_form_for(blueprint, html: { class: 'm-form' } ) do |f| %>
@@ -18,7 +18,7 @@
         <%= f.input :mod_version, as: :select, collection: blueprint.mod ? blueprint.mod.version_list : @mods.first.version_list, selected: blueprint.mod_version || @mods.first.version_list.first, include_blank: false %>
       </div>
       <div class="m-form__important">
-        <%= f.input :encoded_blueprint, label: "Paste your blueprint here", required: true %>
+        <%= f.input :encoded_blueprint, label: "Paste your blueprint here", required: true, input_html: { data: { bp_parser_target: "value", action: "input->bp-parser#parse" } } %>
         <div class="hint-help"><%= link_to "Need help? Don't know what to put here?", help_path(anchor: "copy"), target: '_blank' %></div>
       </div>
       <div class="m-form__tags" data-controller="entitiesTags">
@@ -107,3 +107,47 @@
     <% end %>
   </div>
 </div>
+
+<template id="bp-requirements">
+  <div class="t-blueprint__requirements-preview">
+    <h3>This blueprint requires</h3>
+    <span class="t-blueprint__requirements-total"><strong id="totalStructure"></strong> structures</span>
+    <ul class="t-blueprint__requirements-data" id="bp-entity-list">
+    </ul>
+  </div>
+</template>
+
+<template id="bp-entity">
+  <li class="t-blueprint__requirements-entity">
+    <div class="t-blueprint__requirements-entity__tally">
+      <span class="t-blueprint__requirements-entity__picture" id="entity-image"></span>
+      <div id="entity-tally"></div>
+    </div>
+  </li>
+</template>
+
+<template id="bp-entity-recipes">
+  <ul class="t-blueprint__requirements-entity__recipes">
+  </ul>
+</template>
+
+<template id="bp-entity-recipe">
+  <li class="t-blueprint__requirements-entity__recipe--fixed-margin" id="entity-recipe-image">
+    <div id="entity-recipe-tally"></div>
+  </li>
+</template>
+
+<template id="bp-entity-params">
+  <ul class="t-blueprint__requirements-entity__params"></ul>
+</template>
+
+<template id="bp-entity-param">
+  <li class="t-blueprint__requirements-entity__param">
+    <div id="entity-recipe-image"></div>
+    <ul>
+      <li id="entity-param-local"></li>
+      <li id="entity-param-remote"></li>
+      <li id="entity-param-max"></li>
+    </ul>
+  </li>
+</template>

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@yaireo/tagify": "^3.23.1",
     "brokenmass3dpreview": "https://github.com/gabriel-dehan/brokenmass-3d-preview#1.1.1",
     "clipboard": "^2.0.8",
+    "dsp-bp-parser": "https://github.com/sho918/dsp-bp-parser#de560cd",
     "milligram": "^1.4.1",
     "popper.js": "^1.16.1",
     "rails-erb-loader": "^5.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -951,6 +951,13 @@
   resolved "https://registry.yarnpkg.com/@transloadit/prettier-bytes/-/prettier-bytes-0.0.7.tgz#cdb5399f445fdd606ed833872fa0cabdbc51686b"
   integrity sha512-VeJbUb0wEKbcwaSlj5n+LscBl9IPgLPkHVGBkh00cztv6X4L/TJXK58LzFuBKX7/GAfiGhIwH67YTLTlzvIzBA==
 
+"@types/binary-parser@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@types/binary-parser/-/binary-parser-1.5.1.tgz#248c0d787498f3622c177622e93dfe2478235635"
+  integrity sha512-wxSg5YQFVYsyGwuCSTdBu+cUIYCD9eX0pq3CsJbP4DLeLExbwEPqci9JgjCNHv1ZfLO/QzVtGlasec5xSUcCVA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -973,6 +980,11 @@
   version "14.14.34"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.34.tgz#07935194fc049069a1c56c0c274265abeddf88da"
   integrity sha512-dBPaxocOK6UVyvhbnpFIj2W+S+1cBTkHQbFQfeeJhoKFbzYcVUGHvddeWPSucKATb3F0+pgDq0i6ghEaZjsugA==
+
+"@types/pako@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/pako/-/pako-1.0.2.tgz#17c9b136877f33d9ecc8e73cd26944f1f6dd39a1"
+  integrity sha512-8UJl2MjkqqS6ncpLZqRZ5LmGiFBkbYxocD4e4jmBqGvfRG1RS23gKsBQbdtV9O9GvRyjFTiRHRByjSlKCLlmZw==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -1845,6 +1857,13 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+binary-parser@^1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/binary-parser/-/binary-parser-1.9.2.tgz#6474e30eb2ddee85ab042135e2d011fa80d11438"
+  integrity sha512-aQvTapiRIV/x7bAaR2KT3Ptyjff4R8i1zxljgw/Je2kUt0babNPUdtuo7AKN4CWklyzPK4u5e99Z9/3Ib03u9w==
+  dependencies:
+    fast-text-encoding "^1.0.3"
 
 bindings@^1.5.0:
   version "1.5.0"
@@ -3093,6 +3112,15 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+"dsp-bp-parser@https://github.com/sho918/dsp-bp-parser#de560cd":
+  version "0.1.0"
+  resolved "https://github.com/sho918/dsp-bp-parser#de560cd74db9a84a9da65c9faa96be3a68977db1"
+  dependencies:
+    "@types/binary-parser" "^1.5.1"
+    "@types/pako" "^1.0.2"
+    binary-parser "^1.9.2"
+    pako "^1.0.11"
+
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
@@ -3450,6 +3478,11 @@ fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
+fast-text-encoding@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz#ec02ac8e01ab8a319af182dae2681213cfe9ce53"
+  integrity sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==
 
 faye-websocket@^0.11.3:
   version "0.11.3"


### PR DESCRIPTION
Added ability to display blueprint item composition in upload form.
This allow check blueprint before upload, so probably useful.

In order to reference image files from Javascript, some images are now handled by Webpacker.
If there is any other good way to reference images from Javascript, please let me know.

<details>
<summary>Example image</summary>

- BP Data: https://www.dysonsphereblueprints.com/blueprints/1-universe-matrix-per-second-from-the-ore

![localhost_3000_blueprints_new](https://user-images.githubusercontent.com/3206462/131331577-f7a830f4-5561-4ae0-8aa0-5b52ff4ee643.png)
</details>
