### PR TITLE
Blueprint h2 can break layout due to long words; Encourage breaking into new lines using CSS

### DIFF
--- a/app/assets/stylesheets/organisms/_blueprint_card.scss
+++ b/app/assets/stylesheets/organisms/_blueprint_card.scss
@@ -137,6 +137,7 @@
       font-weight: bold;
       margin: 0;
       font-family: $body-font;
+      word-break: break-word;
 
       a {
         color: var(--white);


### PR DESCRIPTION
This fix issues with content cards breaking layout due to dense content by encouraging words to break across lines

Issue:
<img width="1229" alt="Screenshot 2023-08-03 at 04 13 44" src="https://github.com/gabriel-dehan/dyson-sphere-blueprints/assets/7586051/9ab5a926-88b9-46db-9c9c-f206da0b690e">

Fixed:
<img width="1248" alt="Screenshot 2023-08-03 at 04 13 53" src="https://github.com/gabriel-dehan/dyson-sphere-blueprints/assets/7586051/337528e9-55ea-4fbe-880b-1936d2c6c9e0">
