### PR TITLE
chore: pin localstack to an appropriate version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - "6379:6379"
 
   localstack:
-    image: localstack/localstack:latest
+    image: localstack/localstack:0.13.0
     environment:
       - SERVICES=s3
       - DEFAULT_REGION=eu-west-1


### PR DESCRIPTION
When docker-compose.yml was introduced, localstack was only on 0.13.0. They've released many different versions since then and those new versions don't work the same way anymore. Pinning localstack to 0.13.0 will keep local dev environments working until we can upgrade to a newer version.
