### PR TITLE
Fix new versions not being handled correctly

### DIFF
--- a/app/jobs/base_game_manager_job.rb
+++ b/app/jobs/base_game_manager_job.rb
@@ -28,7 +28,7 @@ class BaseGameManagerJob < ApplicationJob
       if response&.present?
         mod_list = JSON.parse(response)
         fetched_patches = mod_list["appnews"]["newsitems"].reverse.map do |news|
-          match = news["title"].match(/Patch Notes (\d+\.\d+\.\d+\.\d+)|\[Version (\d+\.\d+\.\d+\.\d+)\]|Version (\d+\.\d+\.\d+\.\d+)/i).to_a.compact
+          match = news["title"].match(/Patch Notes V?(\d+\.\d+\.\d+\.\d+)|\[Version (\d+\.\d+\.\d+\.\d+)\]|Version (\d+\.\d+\.\d+\.\d+)/i).to_a.compact
           match ? match[1] : nil
         end
         unregistered_versions = fetched_patches.filter { |fetched_patch| !registered_versions[fetched_patch] }


### PR DESCRIPTION
The DSP team has started putting a V before the numbers in their release notes which breaks the base game manager's parsing of the patch notes for new versions. This commit extends the regexp to handle the presence (or lack thereof) of the V in the patch notes, as they've also been very inconsistent.

I pulled the last 100 or so news items from Steam, and stuck the titles into Rubular to make sure the addition doesn't break anything.

<a href="https://rubular.com/r/N4FNwRR4AJwm8O"><img width="1031" alt="Screenshot 2024-02-11 at 7 28 51 PM" src="https://github.com/gabriel-dehan/dyson-sphere-blueprints/assets/77174/f810ae53-20ab-40e9-ae7d-350261f93583"></a>