### PR TITLE
Update gems to reduce compile errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,7 +213,7 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    nio4r (2.5.7)
+    nio4r (2.7.3)
     nokogiri (1.11.2-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.11.2-x64-mingw32)


### PR DESCRIPTION
:wave:

This PR bumps ~msgpack~ (it was already updated. i was on an old branch 😭) nio4r to newer versions that compile on both an Intel Mac and an Apple Silicon Mac, since I code this app on both platforms. 😬😅
