### PR TITLE
fix: make sure alerts cover all UI elements

### DIFF
--- a/app/assets/stylesheets/molecules/_alert.scss
+++ b/app/assets/stylesheets/molecules/_alert.scss
@@ -2,7 +2,7 @@
   position: fixed;
   width: 100%;
   bottom: 0;
-  z-index: 1;
+  z-index: 10;
 }
 
 .m-alert {


### PR DESCRIPTION
After logging in, the authenticated banner now covers all the UI elements completely.

Before:
<img width="2526" height="135" alt="Screenshot From 2025-09-25 20-36-19" src="https://github.com/user-attachments/assets/1bcfb580-8f7d-4555-a280-9890d6d4f049" />


After:
<img width="2526" height="135" alt="Screenshot From 2025-09-25 20-38-35" src="https://github.com/user-attachments/assets/a449e6a0-08aa-458a-b403-131e0a32af8f" />
