### PR TITLE
Update Gem: dsp_blueprint_parser 0.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
       railties (>= 3.2)
     down (5.2.0)
       addressable (~> 2.5)
-    dsp_blueprint_parser (0.2.0)
+    dsp_blueprint_parser (0.2.2)
     erubi (1.10.0)
     execjs (2.7.0)
     faraday (1.3.0)


### PR DESCRIPTION
New version of gem no longer includes the compiled `.so` file. 