### PR TITLE
Add "Trending" - Filter to Blueprints on front page.

### DIFF
--- a/app/assets/stylesheets/organisms/_blueprint_filters.scss
+++ b/app/assets/stylesheets/organisms/_blueprint_filters.scss
@@ -16,7 +16,7 @@
 
     &.mecha_order-container {
       .o-blueprint-filters__order-container {
-        width: 36.6%;
+        width: 60%;
       }
     }
 
@@ -154,7 +154,7 @@
   }
 
   &__order-container {
-    width: 25%;
+    width: 60%;
   }
 
   &__order {
@@ -226,7 +226,7 @@
     // margin-top: 15px;
 
     a, input[type='submit'] {
-      min-width: 268px;
+      min-width: 120px;
       border-color: var(--dark-red);
       background: var(--dark-red);
       color: var(--white);

--- a/app/controllers/concerns/blueprints_filters.rb
+++ b/app/controllers/concerns/blueprints_filters.rb
@@ -83,6 +83,8 @@ module BlueprintsFilters
 
       if @filters[:order] == "recent"
         blueprints = blueprints.reorder(created_at: :desc)
+      elsif @filters[:order] == "trending"
+        blueprints = blueprints.trending
       elsif @filters[:order] == "popular"
         blueprints = blueprints.reorder(cached_votes_total: :desc)
       elsif @filters[:order] == "usage"

--- a/app/javascript/config.js.erb
+++ b/app/javascript/config.js.erb
@@ -1,1 +1,1 @@
-window._cdnURL = "<%= ENV['AWS_CLOUDFRONT_URL'] %>";
+window._cdnURL = "<%= ENV['AWS_CLOUDFRONT_URL'] || '' %>";

--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -13,18 +13,18 @@ class Blueprint < ApplicationRecord
   RECENT_ACTIVITY_MULTIPLIER = 2.0
   TOTAL_VOTE_WEIGHT = 2.0
   TOTAL_USAGE_WEIGHT = 1.0
-  
+
   # Time boost constants
   NEW_BLUEPRINT_WINDOW = 30.days
   NEW_BLUEPRINT_BOOST = 1.3
   RECENT_BLUEPRINT_WINDOW = 60.days
   RECENT_BLUEPRINT_BOOST = 1.15
   OLD_BLUEPRINT_BOOST = 1.0
-  
+
   # Other configuration
   MAX_ADDITIONAL_PICTURES = 4
   BLUEPRINTS_PER_PAGE = 32
-  RETRO_COMPATIBILITY_VERSION = "2.0.6"
+  RETRO_COMPATIBILITY_VERSION = "2.0.6".freeze
 
   paginates_per BLUEPRINTS_PER_PAGE
 
@@ -60,10 +60,10 @@ class Blueprint < ApplicationRecord
     recent_window_ago = connection.quote(RECENT_WINDOW.ago)
     new_blueprint_days = (NEW_BLUEPRINT_WINDOW / 1.day).to_i
     recent_blueprint_days = (RECENT_BLUEPRINT_WINDOW / 1.day).to_i
-    
+
     # Use light_query columns (exclude encoded_blueprint to avoid memory issues)
     light_columns = (column_names - ["encoded_blueprint"]).map { |col| "blueprints.#{col}" }.join(", ")
-    
+
     # rubocop:disable Rails/SquishedSQLHeredocs
     trending_query = <<-SQL
       WITH recent_votes AS (

--- a/app/views/blueprints/shared/filters/_sorter.html.erb
+++ b/app/views/blueprints/shared/filters/_sorter.html.erb
@@ -5,6 +5,10 @@
       <%= f.label :order_recent, t('blueprints.filters.most_recent') %>
     </div>
     <div class="o-blueprint-filters__order-choice">
+      <%= f.radio_button :order, "trending", checked: filters[:order] === 'trending', data: { 'action': "change->submitOnClick#submit" } %>
+      <%= f.label :order_trending, t('blueprints.filters.trending') %>
+    </div>
+    <div class="o-blueprint-filters__order-choice">
       <%= f.radio_button :order, "popular", checked: filters[:order] === 'popular', data: { 'action': "change->submitOnClick#submit" } %>
       <%= f.label :order_popular, t('blueprints.filters.most_popular') %>
     </div>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -49,6 +49,9 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Use inline job processing in tests to avoid Redis dependency
+  config.active_job.queue_adapter = :inline
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/config/locales/en/views/blueprints.en.yml
+++ b/config/locales/en/views/blueprints.en.yml
@@ -15,6 +15,7 @@ en:
       max_structures: Max structures
       mechas: Mechas
       most_popular: Most Popular
+      trending: Trending
       most_recent: Most recent
       most_used: Most used
       no_dyson_sphere_filters: No specific filters for dyson spheres yet

--- a/config/locales/en/views/blueprints.en.yml
+++ b/config/locales/en/views/blueprints.en.yml
@@ -15,7 +15,6 @@ en:
       max_structures: Max structures
       mechas: Mechas
       most_popular: Most Popular
-      trending: Trending
       most_recent: Most recent
       most_used: Most used
       no_dyson_sphere_filters: No specific filters for dyson spheres yet
@@ -23,6 +22,7 @@ en:
       search: Search
       search_by_author_placeholder: Search by author...
       search_placeholder: Search for a blueprint...
+      trending: Trending
     form:
       additional_no_overwrite: "*Uploading new images will <strong>NOT</strong> overwrite existing ones. To remove existing images, click on the pictures below and then update the blueprint."
       additional_pictures: Additional pictures

--- a/config/locales/zh-CN/views/blueprints.zh-CN.yml
+++ b/config/locales/zh-CN/views/blueprints.zh-CN.yml
@@ -15,6 +15,7 @@ zh-CN:
       max_structures: 最大建筑数量
       mechas: 机甲
       most_popular: 最热门
+      trending: 正在流行
       most_recent: 最新
       most_used: 使用最多
       no_dyson_sphere_filters: 戴森球暂无特定筛选条件

--- a/config/locales/zh-CN/views/blueprints.zh-CN.yml
+++ b/config/locales/zh-CN/views/blueprints.zh-CN.yml
@@ -15,7 +15,6 @@ zh-CN:
       max_structures: 最大建筑数量
       mechas: 机甲
       most_popular: 最热门
-      trending: 正在流行
       most_recent: 最新
       most_used: 使用最多
       no_dyson_sphere_filters: 戴森球暂无特定筛选条件
@@ -23,6 +22,7 @@ zh-CN:
       search: 搜索
       search_by_author_placeholder: 搜索作者...
       search_placeholder: 搜索蓝图...
+      trending: 正在流行
     form:
       additional_no_overwrite: "*上传新图片<strong>不会</strong>覆盖现有图片。要删除现有图片，请点击下方图片，然后更新蓝图。"
       additional_pictures: 附加图片

--- a/db/migrate/20260119000000_add_trending_indexes_to_votes_and_metrics.rb
+++ b/db/migrate/20260119000000_add_trending_indexes_to_votes_and_metrics.rb
@@ -1,0 +1,14 @@
+class AddTrendingIndexesToVotesAndMetrics < ActiveRecord::Migration[6.1]
+  def change
+    # Index for votes query in trending calculation
+    # Supports: WHERE votable_type = 'Blueprint' AND votable_id = X AND created_at >= Y
+    add_index :votes, [:votable_type, :votable_id, :created_at],
+              name: 'index_votes_on_votable_and_created_at'
+    
+    # Index for blueprint_usage_metrics query in trending calculation
+    # Supports: WHERE blueprint_id = X AND last_used_at >= Y
+    add_index :blueprint_usage_metrics, [:blueprint_id, :last_used_at],
+              name: 'index_blueprint_usage_metrics_on_blueprint_and_last_used'
+  end
+end
+

--- a/db/migrate/20260119000000_add_trending_indexes_to_votes_and_metrics.rb
+++ b/db/migrate/20260119000000_add_trending_indexes_to_votes_and_metrics.rb
@@ -3,12 +3,10 @@ class AddTrendingIndexesToVotesAndMetrics < ActiveRecord::Migration[6.1]
     # Index for votes query in trending calculation
     # Supports: WHERE votable_type = 'Blueprint' AND votable_id = X AND created_at >= Y
     add_index :votes, [:votable_type, :votable_id, :created_at],
-              name: 'index_votes_on_votable_and_created_at'
-    
+              name: "index_votes_on_votable_and_created_at"
     # Index for blueprint_usage_metrics query in trending calculation
     # Supports: WHERE blueprint_id = X AND last_used_at >= Y
     add_index :blueprint_usage_metrics, [:blueprint_id, :last_used_at],
-              name: 'index_blueprint_usage_metrics_on_blueprint_and_last_used'
+              name: "index_blueprint_usage_metrics_on_blueprint_and_last_used"
   end
 end
-

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_12_31_144215) do
+ActiveRecord::Schema.define(version: 2026_01_19_000000) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
@@ -69,9 +68,10 @@ ActiveRecord::Schema.define(version: 2025_12_31_144215) do
     t.bigint "blueprint_id"
     t.bigint "user_id"
     t.integer "count", default: 0, null: false
-    t.datetime "last_used_at", default: "2022-02-01 23:53:45"
+    t.datetime "last_used_at", default: "2026-01-07 14:39:35"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["blueprint_id", "last_used_at"], name: "index_blueprint_usage_metrics_on_blueprint_and_last_used"
     t.index ["blueprint_id"], name: "index_blueprint_usage_metrics_on_blueprint_id"
     t.index ["user_id"], name: "index_blueprint_usage_metrics_on_user_id"
   end
@@ -220,6 +220,7 @@ ActiveRecord::Schema.define(version: 2025_12_31_144215) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["votable_id", "votable_type", "vote_scope"], name: "index_votes_on_votable_id_and_votable_type_and_vote_scope"
+    t.index ["votable_type", "votable_id", "created_at"], name: "index_votes_on_votable_and_created_at"
     t.index ["votable_type", "votable_id"], name: "index_votes_on_votable_type_and_votable_id"
     t.index ["voter_id", "voter_type", "vote_scope"], name: "index_votes_on_voter_id_and_voter_type_and_vote_scope"
     t.index ["voter_type", "voter_id"], name: "index_votes_on_voter_type_and_voter_id"

--- a/test/models/blueprint_test.rb
+++ b/test/models/blueprint_test.rb
@@ -94,7 +94,7 @@ class BlueprintTest < ActiveSupport::TestCase
     tags = blueprint.tags_without_mass_construction
 
     # Should not include mass construction tags
-    assert_empty tags.select { |tag| tag.name =~ /mass construction/i }
+    assert_empty(tags.select { |tag| tag.name =~ /mass construction/i })
   end
 
   # ============================================
@@ -105,7 +105,7 @@ class BlueprintTest < ActiveSupport::TestCase
     results = Blueprint.search_by_title("Factory")
 
     assert results.any?
-    assert results.all? { |bp| bp.title.downcase.include?("factory") }
+    assert(results.all? { |bp| bp.title.downcase.include?("factory") })
   end
 
   test "search_by_title returns empty for non-matching query" do
@@ -209,7 +209,7 @@ class BlueprintTest < ActiveSupport::TestCase
   test "trending scope weights recent votes more heavily" do
     # Create a blueprint with recent vote
     blueprint = blueprints(:public_factory)
-    
+
     # Create a recent vote (within last 7 days)
     ActsAsVotable::Vote.create!(
       votable_type: "Blueprint",
@@ -224,7 +224,7 @@ class BlueprintTest < ActiveSupport::TestCase
     result = results.first
 
     if result
-      assert result.trending_score > 0,
+      assert result.trending_score.positive?,
              "Blueprint with recent vote should have positive trending score"
     end
   end
@@ -232,7 +232,7 @@ class BlueprintTest < ActiveSupport::TestCase
   test "trending scope weights recent usage more heavily" do
     # Create a blueprint with recent usage
     blueprint = blueprints(:public_factory)
-    
+
     # Create a recent usage metric (within last 7 days)
     BlueprintUsageMetric.create!(
       blueprint_id: blueprint.id,
@@ -245,7 +245,7 @@ class BlueprintTest < ActiveSupport::TestCase
     result = results.first
 
     if result
-      assert result.trending_score > 0,
+      assert result.trending_score.positive?,
              "Blueprint with recent usage should have positive trending score"
     end
   end
@@ -277,7 +277,7 @@ class BlueprintTest < ActiveSupport::TestCase
     if new_result && old_result
       # New blueprint should have higher score due to time boost
       # (even if old blueprint has more votes/usage)
-      assert new_result.trending_score > 0,
+      assert new_result.trending_score.positive?,
              "New blueprint should have positive trending score"
     end
 
@@ -286,7 +286,7 @@ class BlueprintTest < ActiveSupport::TestCase
 
   test "trending scope only counts votes for Blueprint type" do
     blueprint = blueprints(:public_factory)
-    
+
     # Create a vote for this blueprint
     vote = ActsAsVotable::Vote.create!(
       votable_type: "Blueprint",
@@ -301,7 +301,7 @@ class BlueprintTest < ActiveSupport::TestCase
     result = results.first
 
     if result
-      assert result.trending_score > 0,
+      assert result.trending_score.positive?,
              "Blueprint with vote should have positive trending score"
     end
 

--- a/test/models/blueprint_test.rb
+++ b/test/models/blueprint_test.rb
@@ -145,4 +145,166 @@ class BlueprintTest < ActiveSupport::TestCase
       bp.collection
     end
   end
+
+  # ============================================
+  # TRENDING SCOPE TESTS
+  # ============================================
+
+  test "trending scope returns blueprints" do
+    results = Blueprint.trending
+
+    assert results.respond_to?(:each)
+    assert results.respond_to?(:order)
+  end
+
+  test "trending scope orders by trending_score descending" do
+    results = Blueprint.trending.limit(10).to_a
+
+    # Should be ordered by trending_score DESC
+    scores = results.map { |bp| bp.trending_score || 0 }
+    assert_equal scores, scores.sort.reverse
+  end
+
+  test "trending scope includes trending_score attribute" do
+    results = Blueprint.trending.limit(1).to_a
+
+    if results.any?
+      assert results.first.respond_to?(:trending_score)
+      assert_kind_of Numeric, results.first.trending_score
+    end
+  end
+
+  test "trending scope gives higher score to blueprints with more votes" do
+    # Create two blueprints with different vote counts
+    high_votes = blueprints(:public_dyson_sphere) # 25 votes
+    low_votes = blueprints(:private_factory) # 0 votes
+
+    results = Blueprint.trending.where(id: [high_votes.id, low_votes.id]).to_a
+
+    high_votes_result = results.find { |bp| bp.id == high_votes.id }
+    low_votes_result = results.find { |bp| bp.id == low_votes.id }
+
+    if high_votes_result && low_votes_result
+      assert high_votes_result.trending_score > low_votes_result.trending_score,
+             "Blueprint with more votes should have higher trending score"
+    end
+  end
+
+  test "trending scope gives higher score to blueprints with more usage" do
+    # Create two blueprints with different usage counts
+    high_usage = blueprints(:public_dyson_sphere) # 15 usage
+    low_usage = blueprints(:private_factory) # 0 usage
+
+    results = Blueprint.trending.where(id: [high_usage.id, low_usage.id]).to_a
+
+    high_usage_result = results.find { |bp| bp.id == high_usage.id }
+    low_usage_result = results.find { |bp| bp.id == low_usage.id }
+
+    if high_usage_result && low_usage_result
+      assert high_usage_result.trending_score > low_usage_result.trending_score,
+             "Blueprint with more usage should have higher trending score"
+    end
+  end
+
+  test "trending scope weights recent votes more heavily" do
+    # Create a blueprint with recent vote
+    blueprint = blueprints(:public_factory)
+    
+    # Create a recent vote (within last 7 days)
+    ActsAsVotable::Vote.create!(
+      votable_type: "Blueprint",
+      votable_id: blueprint.id,
+      voter_type: "User",
+      voter_id: users(:admin).id,
+      vote_flag: true,
+      created_at: 1.day.ago
+    )
+
+    results = Blueprint.trending.where(id: blueprint.id).to_a
+    result = results.first
+
+    if result
+      assert result.trending_score > 0,
+             "Blueprint with recent vote should have positive trending score"
+    end
+  end
+
+  test "trending scope weights recent usage more heavily" do
+    # Create a blueprint with recent usage
+    blueprint = blueprints(:public_factory)
+    
+    # Create a recent usage metric (within last 7 days)
+    BlueprintUsageMetric.create!(
+      blueprint_id: blueprint.id,
+      user_id: users(:admin).id,
+      count: 1,
+      last_used_at: 1.day.ago
+    )
+
+    results = Blueprint.trending.where(id: blueprint.id).to_a
+    result = results.first
+
+    if result
+      assert result.trending_score > 0,
+             "Blueprint with recent usage should have positive trending score"
+    end
+  end
+
+  test "trending scope gives time boost to newer blueprints" do
+    # Create a new blueprint (within last 7 days)
+    new_blueprint = Blueprint::Factory.create!(
+      title: "New Trending Blueprint",
+      encoded_blueprint: blueprints(:public_factory).encoded_blueprint,
+      cover_picture_data: blueprints(:public_factory).cover_picture_data,
+      collection_id: collections(:member_public).id,
+      game_version_id: 1,
+      game_version_string: "0.9.27.15466",
+      cached_votes_total: 1,
+      usage_count: 1,
+      tag_list: "production",
+      created_at: 1.day.ago
+    )
+
+    # Create an old blueprint (older than 30 days)
+    old_blueprint = blueprints(:public_dyson_sphere)
+    old_blueprint.update!(created_at: 2.months.ago)
+
+    results = Blueprint.trending.where(id: [new_blueprint.id, old_blueprint.id]).to_a
+
+    new_result = results.find { |bp| bp.id == new_blueprint.id }
+    old_result = results.find { |bp| bp.id == old_blueprint.id }
+
+    if new_result && old_result
+      # New blueprint should have higher score due to time boost
+      # (even if old blueprint has more votes/usage)
+      assert new_result.trending_score > 0,
+             "New blueprint should have positive trending score"
+    end
+
+    new_blueprint.destroy
+  end
+
+  test "trending scope only counts votes for Blueprint type" do
+    blueprint = blueprints(:public_factory)
+    
+    # Create a vote for this blueprint
+    vote = ActsAsVotable::Vote.create!(
+      votable_type: "Blueprint",
+      votable_id: blueprint.id,
+      voter_type: "User",
+      voter_id: users(:admin).id,
+      vote_flag: true,
+      created_at: 1.day.ago
+    )
+
+    results = Blueprint.trending.where(id: blueprint.id).to_a
+    result = results.first
+
+    if result
+      assert result.trending_score > 0,
+             "Blueprint with vote should have positive trending score"
+    end
+
+    vote.destroy
+  end
 end


### PR DESCRIPTION
2nd try :)

I have added the "Trending"-Filter option to the front page in the blueprints section.  adds #75 
Since I don't have access to the production blueprints data it would be nice, if you could test it @gabriel-dehan and @mattr-.

It's basically this:

 Calculate trending score for all blueprints (no time restriction)
 Older blueprints can trend again if they get recent engagement

What counts:
- Votes (likes): Recent votes (last 7 days) × 3.0, Total votes × 2.0
- Copies/Downloads: Recent copies (last 7 days) × 1.5, Total copies × 1.0
- Upload Time boost: 7 days = 30% boost, 30 days = 15% boost, older = no boost
     
Feel free to tweak the multipliers to your liking.

For adding the test I used AI and for the Chinese Translation I used a translation tool, hope it is right. 

<img width="1194" height="203" alt="grafik" src="https://github.com/user-attachments/assets/df57a3f3-2902-4f2a-8c23-8f7c4a006713" />

