### PR TITLE
fix copy not working only on homepage

### DIFF
--- a/app/controllers/blueprints_controller.rb
+++ b/app/controllers/blueprints_controller.rb
@@ -1,7 +1,7 @@
 class BlueprintsController < ApplicationController
   include BlueprintsFilters
 
-  skip_before_action :authenticate_user!, only: [:index, :show]
+  skip_before_action :authenticate_user!, only: [:index, :show, :code]
   before_action :set_cache_headers, only: [:index, :show]
 
   def show

--- a/test/controllers/blueprints_controller_test.rb
+++ b/test/controllers/blueprints_controller_test.rb
@@ -180,12 +180,15 @@ class BlueprintsControllerTest < ActionDispatch::IntegrationTest
   # CODE TESTS
   # ============================================
 
-  test "code requires authentication" do
-    get code_blueprint_path(blueprints(:public_factory))
-    assert_redirected_to new_user_session_path
+  test "code is accessible without authentication" do
+    blueprint = blueprints(:public_factory)
+    get code_blueprint_path(id: blueprint.id)
+    assert_response :success
+    assert_equal "text/plain", response.media_type
+    assert_equal blueprint.encoded_blueprint, response.body
   end
 
-  test "code returns encoded blueprint as text" do
+  test "code returns encoded blueprint as text when authenticated" do
     sign_in_as(:member)
     blueprint = blueprints(:public_factory)
 


### PR DESCRIPTION
This fixes copy button not working on the home page, only working when you go into the blueprint.

As I understand, the idea was to have copy behind a login wall. Currently, the copy button just returns HTML which breaks pasting blueprints. Either the copy button should redirect, or it should just copy blueprints. This PR does the latter